### PR TITLE
refactor to use promise all instead of await in order

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,7 +3,13 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { lastValueFrom } from 'rxjs';
 
-import { AkcLogger, CONST_CHAR, CONST_NUM, LINK_API, RequestContext } from './shared';
+import {
+  AkcLogger,
+  CONST_CHAR,
+  CONST_NUM,
+  LINK_API,
+  RequestContext,
+} from './shared';
 import { StatusOutput } from './components/dashboard/dtos/status-output.dto';
 import { TransactionService } from './components/transaction/services/transaction.service';
 import { BlockService } from './components/block/services/block.service';
@@ -50,40 +56,61 @@ export class AppService {
 
     // get staking pool
     const paramPool = LINK_API.STAKING_POOL;
-    const poolData = await this.getDataAPI(api, paramPool, ctx);
+    // const poolData = await this.getDataAPI(api, paramPool, ctx);
 
     // get inflation
     const paramInflation = LINK_API.INFLATION;
-    const inflationData = await this.getDataAPI(api, paramInflation, ctx);
+    // const inflationData = await this.getDataAPI(api, paramInflation, ctx);
 
     // get community pool
     const paramComPool = LINK_API.COMMUNITY_POOL;
-    const comPoolData = await this.getDataAPI(api, paramComPool, ctx);
+    // const comPoolData = await this.getDataAPI(api, paramComPool, ctx);
 
     // get blocks by limit 2
-    const { blocks } = await this.blockService.getDataBlocks(ctx, CONST_NUM.LIMIT_2, CONST_NUM.OFFSET);
-    
+    // const { blocks } = await this.blockService.getDataBlocks(ctx, CONST_NUM.LIMIT_2, CONST_NUM.OFFSET);
+
+    const [
+      poolData,
+      inflationData,
+      comPoolData,
+      { blocks },
+      totalValidatorNum,
+      totalValidatorActiveNum,
+      totalTxsNum,
+    ] = await Promise.all([
+      this.getDataAPI(api, paramPool, ctx),
+      this.getDataAPI(api, paramInflation, ctx),
+      this.getDataAPI(api, paramComPool, ctx),
+      this.blockService.getDataBlocks(ctx, CONST_NUM.LIMIT_2, CONST_NUM.OFFSET),
+      this.validatorService.getTotalValidator(),
+      this.validatorService.getTotalValidatorActive(),
+      this.txService.getTotalTx(),
+    ]);
+
     let blockTime;
     let height;
     let comPool;
     if (blocks.length === 2) {
       const block_first = blocks[0].timestamp.getTime();
       const block_second = blocks[1].timestamp.getTime();
-      blockTime = Math.floor(Math.abs(block_first - block_second) / 1000) + CONST_CHAR.SECOND;
+      blockTime =
+        Math.floor(Math.abs(block_first - block_second) / 1000) +
+        CONST_CHAR.SECOND;
       height = blocks[0].height;
     }
-    
+
     const bonded_tokens = parseInt(poolData.pool.bonded_tokens);
-    const inflation = (inflationData.inflation * 100).toFixed(2) + CONST_CHAR.PERCENT;
+    const inflation =
+      (inflationData.inflation * 100).toFixed(2) + CONST_CHAR.PERCENT;
     if (comPoolData) {
       comPool = parseInt(comPoolData.pool[0].amount);
     }
     // get total validator
-    const totalValidatorNum = await this.validatorService.getTotalValidator();
+    // const totalValidatorNum = await this.validatorService.getTotalValidator();
     // get total validator active
-    const totalValidatorActiveNum = await this.validatorService.getTotalValidatorActive();
+    // const totalValidatorActiveNum = await this.validatorService.getTotalValidatorActive();
     // get total tx
-    const totalTxsNum = await this.txService.getTotalTx();
+    // const totalTxsNum = await this.txService.getTotalTx();
 
     return {
       block_height: height,

--- a/src/components/wallet/services/wallet.service.ts
+++ b/src/components/wallet/services/wallet.service.ts
@@ -1,66 +1,94 @@
-import { Injectable } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { AkcLogger, RequestContext } from "../../../shared";
-import { WalletOutput } from "../dtos/wallet-output.dto";
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AkcLogger, RequestContext } from '../../../shared';
+import { WalletOutput } from '../dtos/wallet-output.dto';
 import { lastValueFrom } from 'rxjs';
-import { HttpService } from "@nestjs/axios";
+import { HttpService } from '@nestjs/axios';
 
 @Injectable()
 export class WalletService {
-    constructor(
-        private readonly logger: AkcLogger,
-        private configService: ConfigService,
-        private httpService: HttpService,
-    ) {
-        this.logger.setContext(WalletService.name);
-    }
+  constructor(
+    private readonly logger: AkcLogger,
+    private configService: ConfigService,
+    private httpService: HttpService,
+  ) {
+    this.logger.setContext(WalletService.name);
+  }
 
-    async getWalletDetailByAddress(ctx: RequestContext, address): Promise<any> {
-        this.logger.log(ctx, `${this.getWalletDetailByAddress.name} was called!`);
+  async getWalletDetailByAddress(ctx: RequestContext, address): Promise<any> {
+    this.logger.log(ctx, `${this.getWalletDetailByAddress.name} was called!`);
 
-        const api = this.configService.get<string>('node.api');
-    
-        const walletOutput = new WalletOutput();
-        walletOutput.address = address;
-        //get balance
-        const paramsBalance = `/cosmos/bank/v1beta1/balances/${address}`;
-        const balanceData = await this.getDataAPI(api, paramsBalance);
-        if (balanceData) {
-            walletOutput.balance = balanceData;
-        }
-        //get delegated
-        const paramsDelegated = `/cosmos/staking/v1beta1/delegations/${address}`;
-        const delegatedData = await this.getDataAPI(api, paramsDelegated);
-        if (delegatedData) {
-            walletOutput.delegated = delegatedData;
-        }
-        //get unbonding
-        const paramsUnbonding = `/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`;
-        const unbondingData = await this.getDataAPI(api, paramsUnbonding);
-        if (unbondingData) {
-            walletOutput.unbonding = unbondingData;
-        }
-        //get stake_reward
-        const paramsStakeReward = `/cosmos/distribution/v1beta1/delegators/${address}/rewards`;
-        const stakeRewardData = await this.getDataAPI(api, paramsStakeReward);
-        if (stakeRewardData) {
-            walletOutput.stake_reward = stakeRewardData;
-        }
-        //get auth_info
-        const paramsAuthInfo = `auth/accounts/${address}`;
-        const authInfoData = await this.getDataAPI(api, paramsAuthInfo);
-        if (authInfoData) {
-            walletOutput.auth_info = authInfoData;
-        }
-    
-        return { ...walletOutput };
-    }
+    const api = this.configService.get<string>('node.api');
 
-    async getDataAPI(api, params) {
-        const data = await lastValueFrom(this.httpService.get(api + params)).then(
-          (rs) => rs.data,
-        );
-    
-        return data;
+    const walletOutput = new WalletOutput();
+    walletOutput.address = address;
+    //get balance
+    const paramsBalance = `/cosmos/bank/v1beta1/balances/${address}`;
+    // const balanceData = await this.getDataAPI(api, paramsBalance);
+    // if (balanceData) {
+    //     walletOutput.balance = balanceData;
+    // }
+    //get delegated
+    const paramsDelegated = `/cosmos/staking/v1beta1/delegations/${address}`;
+    // const delegatedData = await this.getDataAPI(api, paramsDelegated);
+    // if (delegatedData) {
+    //     walletOutput.delegated = delegatedData;
+    // }
+    //get unbonding
+    const paramsUnbonding = `/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`;
+    // const unbondingData = await this.getDataAPI(api, paramsUnbonding);
+    // if (unbondingData) {
+    //     walletOutput.unbonding = unbondingData;
+    // }
+    //get stake_reward
+    const paramsStakeReward = `/cosmos/distribution/v1beta1/delegators/${address}/rewards`;
+    // const stakeRewardData = await this.getDataAPI(api, paramsStakeReward);
+    // if (stakeRewardData) {
+    //     walletOutput.stake_reward = stakeRewardData;
+    // }
+    //get auth_info
+    const paramsAuthInfo = `auth/accounts/${address}`;
+    // const authInfoData = await this.getDataAPI(api, paramsAuthInfo);
+    // if (authInfoData) {
+    //     walletOutput.auth_info = authInfoData;
+    // }
+
+    const [
+      balanceData,
+      delegatedData,
+      unbondingData,
+      stakeRewardData,
+      authInfoData,
+    ] = await Promise.all([
+      this.getDataAPI(api, paramsBalance),
+      this.getDataAPI(api, paramsDelegated),
+      this.getDataAPI(api, paramsUnbonding),
+      this.getDataAPI(api, paramsStakeReward),
+      this.getDataAPI(api, paramsAuthInfo),
+    ]);
+    if (balanceData) {
+      walletOutput.balance = balanceData;
     }
+    if (delegatedData) {
+      walletOutput.delegated = delegatedData;
+    }
+    if (unbondingData) {
+      walletOutput.unbonding = unbondingData;
+    }
+    if (stakeRewardData) {
+      walletOutput.stake_reward = stakeRewardData;
+    }
+    if (authInfoData) {
+      walletOutput.auth_info = authInfoData;
+    }
+    return { ...walletOutput };
+  }
+
+  async getDataAPI(api, params) {
+    const data = await lastValueFrom(this.httpService.get(api + params)).then(
+      (rs) => rs.data,
+    );
+
+    return data;
+  }
 }


### PR DESCRIPTION
Fix slow service by using promise.all instead of using await in order in 3 services:
- getAccount
- getWallet
- getStatus
