### PR TITLE
fix: return old format for name tag api

### DIFF
--- a/src/components/name-tag/dtos/store-name-tag-params.dto.ts
+++ b/src/components/name-tag/dtos/store-name-tag-params.dto.ts
@@ -22,6 +22,5 @@ export class StoreNameTagParamsDto {
   @ApiPropertyOptional({
     default: null,
   })
-  @IsUrl(undefined, { message: 'Enterprise url must be a valid url.' })
   enterpriseUrl: string;
 }

--- a/src/components/name-tag/services/name-tag.service.ts
+++ b/src/components/name-tag/services/name-tag.service.ts
@@ -115,13 +115,11 @@ export class NameTagService {
       };
     }
 
-    if (req?.enterpriseUrl) {
-      if (!req.enterpriseUrl.match(REGEX_PARTERN.URL)) {
-        return {
-          code: ADMIN_ERROR_MAP.INVALID_URL.Code,
-          message: ADMIN_ERROR_MAP.INVALID_URL.Message,
-        };
-      }
+    if (req?.enterpriseUrl && !req.enterpriseUrl.match(REGEX_PARTERN.URL)) {
+      return {
+        code: ADMIN_ERROR_MAP.INVALID_URL.Code,
+        message: ADMIN_ERROR_MAP.INVALID_URL.Message,
+      };
     }
 
     if (isCreate) {

--- a/src/components/name-tag/services/name-tag.service.ts
+++ b/src/components/name-tag/services/name-tag.service.ts
@@ -115,6 +115,15 @@ export class NameTagService {
       };
     }
 
+    if (req?.enterpriseUrl) {
+      if (!req.enterpriseUrl.match(REGEX_PARTERN.URL)) {
+        return {
+          code: ADMIN_ERROR_MAP.INVALID_URL.Code,
+          message: ADMIN_ERROR_MAP.INVALID_URL.Message,
+        };
+      }
+    }
+
     if (isCreate) {
       // check duplicate address
       const address = await this.nameTagRepository.findOne({

--- a/src/shared/constants/common.ts
+++ b/src/shared/constants/common.ts
@@ -168,6 +168,10 @@ export const ADMIN_ERROR_MAP = {
     Message:
       'Name tag not accept special character except dot(.), dash(-), underscore(_)',
   },
+  INVALID_URL: {
+    Code: 'E005',
+    Message: 'Invalid URL format',
+  },
 };
 
 export const PAGE_REQUEST = {
@@ -240,7 +244,10 @@ export const VERIFY_STEP = [
 
 export const ROLES_KEY = 'roles';
 
-export const REGEX_PARTERN = { NAME_TAG: new RegExp(/^[a-zA-Z0-9._-\s]+$/) };
+export const REGEX_PARTERN = {
+  NAME_TAG: new RegExp(/^[a-zA-Z0-9._-\s]+$/),
+  URL: new RegExp(/^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/),
+};
 
 export enum USER_ACTIVITIES {
   SEND_MAIL_CONFIRM = 'SEND_MAIL_CONFIRM',


### PR DESCRIPTION
Use custom validate instead of use library