### PR TITLE
[SYNC_PRICE][DEV] Fixing/fix sync price coin

### DIFF
--- a/src/components/queues/token/token.processor.ts
+++ b/src/components/queues/token/token.processor.ts
@@ -162,11 +162,11 @@ export class TokenProcessor {
     if (response) {
       for (let index = 0; index < response.length; index++) {
         const data = response[index];
-        let tokenInfo = tokenInfos?.find((f) => f.coin_id === data.id);
-        if (tokenInfo) {
-          tokenInfo = this.updateTokenMarketsData(tokenInfo, data);
-          coinMarkets.push(tokenInfo);
-        }
+        const tokenInfo = tokenInfos?.filter((f) => f.coin_id === data.id);
+        tokenInfo?.forEach((item) => {
+          const tokenInfoUpdated = this.updateTokenMarketsData(item, data);
+          coinMarkets.push(tokenInfoUpdated);
+        });
       }
     }
     if (coinMarkets.length > 0) {


### PR DESCRIPTION
Bug: sync price khi có coin id giống nhau thì nó chỉ update cho record đầu tiên
Fix: Update hết tất cả các record có cùng coin_id